### PR TITLE
Support bellman in single core mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ version = "0.0.4"
 
 [lib]
 crate-type = ["lib", "staticlib"]
+
+[features]
+default = ["multicore"]
+multicore = ["bellman/multicore"]
  
 [dependencies]
 rand = "0.4"
@@ -19,7 +23,7 @@ serde = "1.0.80"
 serde_derive = "1.0.80"
 tiny-keccak = "1.4.2"
 
-bellman = { git = 'https://github.com/matterinc/bellman', tag = "0.2.0"}
+bellman = { git = 'https://github.com/matterinc/bellman', tag = "0.2.0", default-features = false}
 #bellman = { path = "../bellman"}
 
 [dependencies.blake2-rfc]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde_derive = "1.0.80"
 tiny-keccak = "1.4.2"
 
 #bellman = { path = "../bellman"}
-bellman = { git = 'https://github.com/poma/bellman', default-features = false}
+bellman = { git = 'https://github.com/poma/bellman', tag = '0.2.0', default-features = false}
 
 [dependencies.blake2-rfc]
 git = "https://github.com/gtank/blake2-rfc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ serde = "1.0.80"
 serde_derive = "1.0.80"
 tiny-keccak = "1.4.2"
 
-bellman = { git = 'https://github.com/matterinc/bellman', tag = "0.2.0", default-features = false}
 #bellman = { path = "../bellman"}
+bellman = { git = 'https://github.com/poma/bellman', default-features = false}
 
 [dependencies.blake2-rfc]
 git = "https://github.com/gtank/blake2-rfc"


### PR DESCRIPTION
Currently including this lib will force bellman dependency into multi core mode. Now it is possible to use it with single core for wasm-friendly compilation. The default is still multicore.