### PR TITLE
replace rust-crypto with sha2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,16 @@ crate-type = ["lib", "staticlib"]
 default = ["multicore"]
 multicore = ["bellman/multicore"]
 nightly = ["bellman/nightly"]
+wasm = ["bellman/wasm"]
  
 [dependencies]
 rand = "0.4"
 digest = "0.7"
 byteorder = "1"
 tiny-keccak = "1.4.2"
-rust-crypto = "0.2"
 serde = "1.0.80"
 serde_derive = "1.0.80"
+sha2 = "0.8.0"
 
 #bellman = {package = "bellman_ce", path = "../bellman"}
 bellman = {package = "bellman_ce", version = "0.3.1", default-features = false}

--- a/src/circuit/sha256.rs
+++ b/src/circuit/sha256.rs
@@ -367,8 +367,7 @@ mod test {
 
     #[test]
     fn test_against_vectors() {
-        use crypto::sha2::Sha256;
-        use crypto::digest::Digest;
+        use sha2::{Sha256, Digest};
 
         let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
 
@@ -377,8 +376,8 @@ mod test {
             let mut h = Sha256::new();
             let data: Vec<u8> = (0..input_len).map(|_| rng.gen()).collect();
             h.input(&data);
-            let mut hash_result = [0u8; 32];
-            h.result(&mut hash_result[..]);
+            let result = h.result();
+            let hash_result = result.as_slice();
 
             let mut cs = TestConstraintSystem::<Bls12>::new();
             let mut input_bits = vec![];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ extern crate digest;
 extern crate rand;
 extern crate byteorder;
 extern crate tiny_keccak;
-extern crate crypto;
+extern crate sha2;
 
 #[cfg(test)]
 #[macro_use]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,9 +1,8 @@
 use blake2_rfc::blake2b::Blake2b;
 use blake2_rfc::blake2s::Blake2s;
-use crypto::sha2::Sha256;
+use sha2::{Sha256, Digest};
 
 use jubjub::{JubjubEngine, ToUniform};
-
 
 pub fn hash_to_scalar<E: JubjubEngine>(persona: &[u8], a: &[u8], b: &[u8]) -> E::Fs {
     let mut hasher = Blake2b::with_params(64, &[], &[], persona);
@@ -22,12 +21,10 @@ pub fn hash_to_scalar_s<E: JubjubEngine>(persona: &[u8], a: &[u8], b: &[u8]) -> 
 }
 
 pub fn sha256_hash_to_scalar<E: JubjubEngine>(persona: &[u8], a: &[u8], b: &[u8]) -> E::Fs {
-    use crypto::digest::Digest;
     let mut hasher = Sha256::new();
     hasher.input(persona);
     hasher.input(a);
     hasher.input(b);
-    let mut bytes = [0u8; 32];
-    hasher.result(&mut bytes[..]);
-    E::Fs::to_uniform_32(bytes.as_ref())
+    let result = hasher.result();
+    E::Fs::to_uniform_32(result.as_slice())
 }


### PR DESCRIPTION
These changes fix the issues with compiling to wasm.

Related to issue [https://github.com/matter-labs/sapling-crypto/issues/11](https://github.com/matter-labs/sapling-crypto/issues/11).