### PR TITLE
Better implementation of Num::add_assign.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ wasm = ["bellman/wasm"]
 [dependencies]
 rand = "0.4"
 digest = "0.8"
+fnv = "1.0.3"
 byteorder = "1"
 tiny-keccak = {version = "2.0", features = ["keccak"] }
 serde = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 pub extern crate bellman;
 extern crate blake2_rfc_bellman_edition as blake2_rfc;
 extern crate digest;
+extern crate fnv;
 extern crate rand;
 extern crate byteorder;
 extern crate tiny_keccak;


### PR DESCRIPTION
The original implementation of Num::add_assign had a few inefficiencies:

   * It instantiated the standard hashmap with small keys.
   * It put a bunch of items into an empty hashmap, without setting the
     intial hashmap capacity.
   * It used multiple hash lookups in an insert-or-modify pattern.

This commit:

   * Uses the Fnv hash function instead of the default: SipHash.
   * Initializes the hashmap with appropriate capacity.
   * Uses the entry API.

In my microbenchmarks, this sped up Poseidon evaluation by 1.7x.