### PR TITLE
Reduce Poseidon hash rounds, following 2019/458.

### DIFF
--- a/src/circuit/poseidon_hash.rs
+++ b/src/circuit/poseidon_hash.rs
@@ -262,6 +262,7 @@ fn poseidon_mimc_round<E: PoseidonEngine<SBox = QuinticSBox<E> >, CS>(
     let r_f = params.r_f();
     let r_p = params.r_p();
     let t = params.t();
+    let pre_full_rounds = r_f - r_f / 2;
 
     fn add_round_constants<E: PoseidonEngine, CS>(
         params: &E::Params,
@@ -286,7 +287,7 @@ fn poseidon_mimc_round<E: PoseidonEngine<SBox = QuinticSBox<E> >, CS>(
 
     // do releated applications of MDS and then round constants and s-boxes
 
-    for full_round in 0..(r_f-1) {
+    for full_round in 0..(pre_full_rounds - 1) {
         let s_box_applied = E::SBox::apply_sbox(
             cs.namespace(|| format!("apply s-box for full round {}", full_round)),
             &state[..]
@@ -316,7 +317,7 @@ fn poseidon_mimc_round<E: PoseidonEngine<SBox = QuinticSBox<E> >, CS>(
     // transformation and add first round constants before going through partial rounds
     {
         let s_box_applied = E::SBox::apply_sbox(
-            cs.namespace(|| format!("apply s-box for full round {}", r_f-1)),
+            cs.namespace(|| format!("apply s-box for full round {}", pre_full_rounds-1)),
             &state[..]
         )?;
 
@@ -376,13 +377,13 @@ fn poseidon_mimc_round<E: PoseidonEngine<SBox = QuinticSBox<E> >, CS>(
             linear_transformation_results.push(linear_applied);
         }
 
-        add_round_constants::<E, CS>(params, &mut linear_transformation_results[..], r_f, true);
+        add_round_constants::<E, CS>(params, &mut linear_transformation_results[..], pre_full_rounds, true);
         state = linear_transformation_results;
 
         round += 1;
     }
 
-    for full_round in r_f..(2*r_f - 1) {
+    for full_round in pre_full_rounds..(r_f - 1) {
         let s_box_applied = E::SBox::apply_sbox(
             cs.namespace(|| format!("apply s-box for full round {}", full_round)),
             &state[..]
@@ -403,9 +404,10 @@ fn poseidon_mimc_round<E: PoseidonEngine<SBox = QuinticSBox<E> >, CS>(
     }
 
     // for a final round we only apply s-box
+    let full_round = r_f - 1;
 
     let state = E::SBox::apply_sbox(
-            cs.namespace(|| format!("apply s-box for full round {}", 2*r_f - 1)),
+            cs.namespace(|| format!("apply s-box for full round {}", full_round)),
             &state[..]
         )?;
 

--- a/src/poseidon/bn256.rs
+++ b/src/poseidon/bn256.rs
@@ -20,7 +20,7 @@ impl Bn256PoseidonParams {
     pub fn new<H: GroupHasher>() -> Self {
         let t = 6u32;
         let r_f = 8u32;
-        let r_p = 84u32;
+        let r_p = 57u32;
         let security_level = 126u32;
 
         Self::new_for_params::<H>(t, r_f, r_p, security_level)

--- a/src/poseidon/mod.rs
+++ b/src/poseidon/mod.rs
@@ -171,8 +171,9 @@ pub fn poseidon_mimc<E: PoseidonEngine>(
 
     let r_f = params.r_f();
     let r_p = params.r_p();
+    let pre_full_rounds = r_f - r_f / 2;
 
-    for full_round in 0..r_f {
+    for full_round in 0..pre_full_rounds {
         let round_constants = params.full_round_key(full_round);
         for (el, c) in state.iter_mut().zip(round_constants.iter()) {
             el.add_assign(c);
@@ -211,8 +212,7 @@ pub fn poseidon_mimc<E: PoseidonEngine>(
 
     // reference implementation says that last round does not have matrix muptiplication step,
     // that is true due to ease of inversion
-    for full_round in r_f..(2*r_f - 1) {
-    // for full_round in r_f..(2*r_f) {
+    for full_round in pre_full_rounds..(r_f - 1) {
         let round_constants = params.full_round_key(full_round);
         for (el, c) in state.iter_mut().zip(round_constants.iter()) {
             el.add_assign(c);
@@ -231,7 +231,7 @@ pub fn poseidon_mimc<E: PoseidonEngine>(
     }
 
     {
-        let full_round = 2*r_f - 1;
+        let full_round = r_f - 1;
         let round_constants = params.full_round_key(full_round);
         for (el, c) in state.iter_mut().zip(round_constants.iter()) {
             el.add_assign(c);


### PR DESCRIPTION
This commit reduces the number of rounds in the Poseidon hash function
in two ways:

   * It correctly interprets the `R_F` parameter as the **total** number
     of full rounds.
      * The previous implementation incorrectly interpretted the `R_F`
        parameter as the number of full rounds **on each side**. That is
        actually the `R_f` parameter.
      * Relevant citation: 2019/458, page 6, paragraph 3.
   * It sets the number of partial rounds to 57, as is reccomended for
     x^5-Poseidon
      * The previous value, 84, is the reccomended number of partial
        rounds for x^3-Poseidon.
      * Relevant citation: 2019/458, table 3, row 3.

Note that before this commit, the Poseidon implementation **was not
vulnerable, to the best of our knowledge**. While the implementation
appears to have made two mistakes, it made these mistakes in a way that
improved, not reduced, the security.