### PR TITLE
Require `JubjubParams` to be Send and Sync.

### DIFF
--- a/src/jubjub/mod.rs
+++ b/src/jubjub/mod.rs
@@ -105,7 +105,7 @@ pub trait JubjubEngine: Engine {
 
 /// The pre-computed parameters for Jubjub, including curve
 /// constants and various limits and window tables.
-pub trait JubjubParams<E: JubjubEngine>: Sized {
+pub trait JubjubParams<E: JubjubEngine>: Sized + Send + Sync {
     /// The `d` constant of the twisted Edwards curve.
     fn edwards_d(&self) -> &E::Fr;
     /// The `A` constant of the birationally equivalent Montgomery curve.


### PR DESCRIPTION
ANy reasonable parameter implementation would have this, and marking it
allows parameter-generic hash-using functions to parallelize hashing.